### PR TITLE
Update TrueOS-Cheatsheet

### DIFF
--- a/TrueOS-Cheatsheet
+++ b/TrueOS-Cheatsheet
@@ -398,3 +398,4 @@ At the boot-loader menu, drop to the Command-Prompt (Under Advanced). Run the co
 Once you’ve come up with a working resolution you can hard-code it by putting the 'gop set ’ command in /boot/loader.rc.local.
 original link --> UEFI Resolution
 https://github.com/trueos/trueos/wiki/UEFI-Resolution
+


### PR DESCRIPTION
if the user wishes to start  attempting to compile programs from the ports tree. the user will need to the following to accomplish this task


24: make sure that you remove anything in /usr/ports

	sudo rm -rf * /usr/ports

grab the trueos ports tree

	git clone https://github.com/trueos/trueos-ports /usr/ports


25: now to install the development packages
	
	pkg install -g "OS-*-development"